### PR TITLE
Fix dotprod detection

### DIFF
--- a/posix_helper.sh
+++ b/posix_helper.sh
@@ -68,7 +68,7 @@ case $uname_s in
       'aarch64')
         file_os='android'
         file_arch='armv8'
-        if check_flags 'dotprod'; then
+        if check_flags 'asimddp'; then
           file_arch="$file_arch-dotprod"
         fi
         ;;


### PR DESCRIPTION
Same as official-stockfish/Stockfish#4991

This fixes the detection of dotprod capable CPUs.
Previously it looked for the `dotprod` flag,
but this does not exist (https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/arch/arm64/kernel/cpuinfo.c#n50). The correct flag that specifies the dotprod capability is the `asimddp` flag.